### PR TITLE
feat(admin): implement CRUD for competition management #13

### DIFF
--- a/admin/_footer.php
+++ b/admin/_footer.php
@@ -1,0 +1,5 @@
+</main> </div> <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
+    
+    <script type="module" src="../assets/js/main.js"></script>
+</body>
+</html>

--- a/admin/_header.php
+++ b/admin/_header.php
@@ -1,0 +1,18 @@
+<?php
+// Panggil auth.php di setiap halaman admin yang terproteksi
+// Ini akan otomatis memulai session dan memeriksa hak akses
+require_once 'auth.php';
+?>
+<!DOCTYPE html>
+<html lang="id">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?php echo isset($pageTitle) ? htmlspecialchars($pageTitle) : 'Admin Panel'; ?> - Respect.id</title>
+    
+    <link rel="stylesheet" href="../assets/css/admin.css">
+    
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
+</head>
+<body>
+    <div class="admin-wrapper"></div>

--- a/admin/_sidebar.php
+++ b/admin/_sidebar.php
@@ -1,0 +1,36 @@
+<aside class="sidebar">
+    <div class="sidebar-header">
+        <img src="../assets/images/logo-respect.png" alt="Logo" class="sidebar-logo">
+        <h2>Admin Panel</h2>
+    </div>
+    <nav class="sidebar-nav">
+        <a href="dashboard.php" class="nav-link">
+            <i class="fas fa-tachometer-alt"></i> <span>Dashboard</span>
+        </a>
+        <a href="manage_competitions.php" class="nav-link active">
+            <i class="fas fa-trophy"></i> <span>Manajemen Lomba</span>
+        </a>
+        <a href="#" class="nav-link">
+            <i class="fas fa-newspaper"></i> <span>Manajemen Berita</span>
+        </a>
+        <a href="#" class="nav-link">
+            <i class="fas fa-file-invoice-dollar"></i> <span>Verifikasi Transaksi</span>
+        </a>
+        <a href="#" class="nav-link">
+            <i class="fas fa-users"></i> <span>Manajemen Pengguna</span>
+        </a>
+    </nav>
+    <div class="sidebar-footer">
+        <a href="#" id="admin-logout-btn" class="nav-link logout">
+            <i class="fas fa-sign-out-alt"></i> <span>Logout</span>
+        </a>
+    </div>
+</aside>
+<main class="main-content">
+    <header class="main-header">
+        <h3><?php echo isset($headerTitle) ? htmlspecialchars($headerTitle) : 'Dashboard'; ?></h3>
+        <div class="admin-profile">
+            <span>Halo, <?php echo htmlspecialchars($admin_name); ?></span>
+            <i class="fas fa-user-circle"></i>
+        </div>
+    </header>

--- a/admin/auth.php
+++ b/admin/auth.php
@@ -1,0 +1,14 @@
+<?php
+session_start();
+
+// Periksa apakah user sudah login DAN memiliki peran 'admin'
+if (!isset($_SESSION['user_id']) || !isset($_SESSION['user_role']) || $_SESSION['user_role'] !== 'admin') {
+    // Jika tidak, hancurkan session untuk keamanan dan redirect ke halaman login
+    session_destroy();
+    header('Location: index.php');
+    exit;
+}
+
+// Jika aman, kita bisa simpan nama admin untuk ditampilkan
+$admin_name = $_SESSION['user_nama'];
+?>

--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -1,0 +1,56 @@
+<?php
+$pageTitle = 'Dashboard';
+$headerTitle = 'Dashboard Overview';
+include '_header.php'; // Memanggil header, yang sudah termasuk auth.php
+include '_sidebar.php'; // Memanggil sidebar dan header utama
+?>
+
+<div class="dashboard-stats">
+    <div class="stat-card">
+        <div class="stat-icon users">
+            <i class="fas fa-users"></i>
+        </div>
+        <div class="stat-info">
+            <p>Total Pengguna</p>
+            <span>Memuat...</span>
+        </div>
+    </div>
+    <div class="stat-card">
+        <div class="stat-icon competitions">
+            <i class="fas fa-trophy"></i>
+        </div>
+        <div class="stat-info">
+            <p>Total Lomba</p>
+            <span>Memuat...</span>
+        </div>
+    </div>
+    <div class="stat-card">
+        <div class="stat-icon transactions">
+            <i class="fas fa-file-invoice-dollar"></i>
+        </div>
+        <div class="stat-info">
+            <p>Transaksi Pending</p>
+            <span>Memuat...</span>
+        </div>
+    </div>
+    <div class="stat-card">
+        <div class="stat-icon revenue">
+            <i class="fas fa-money-bill-wave"></i>
+        </div>
+        <div class="stat-info">
+            <p>Total Pendapatan</p>
+            <span>Memuat...</span>
+        </div>
+    </div>
+</div>
+
+<div class="dashboard-content">
+    <div class="content-card">
+        <h4>Aktivitas Terbaru</h4>
+        <p>Fitur ini akan menampilkan pendaftaran atau transaksi terbaru.</p>
+    </div>
+</div>
+
+<?php
+include '_footer.php'; // Memanggil footer
+?>

--- a/admin/index.php
+++ b/admin/index.php
@@ -1,0 +1,55 @@
+<?php
+session_start();
+// Jika admin sudah login, langsung arahkan ke dashboard
+if (isset($_SESSION['user_id']) && isset($_SESSION['user_role']) && $_SESSION['user_role'] === 'admin') {
+    header('Location: dashboard.php');
+    exit;
+}
+$pageTitle = 'Admin Login';
+// Kita tidak menyertakan _head.php biasa karena halaman admin mungkin punya style sendiri
+?>
+<!DOCTYPE html>
+<html lang="id">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?php echo htmlspecialchars($pageTitle); ?> - Respect.id</title>
+    <link rel="stylesheet" href="../assets/css/style.css">
+    <style>
+        /* Style khusus untuk halaman login admin */
+        .admin-login-container {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+            background: var(--background-light);
+        }
+        .admin-login-card {
+            width: 100%;
+            max-width: 400px;
+        }
+    </style>
+</head>
+<body>
+    <main class="admin-login-container">
+        <div class="register-card admin-login-card">
+            <div style="text-align: center; margin-bottom: 2rem;">
+                <img src="../assets/images/logo-respect.png" alt="Respect Logo" style="width: 80px;">
+            </div>
+            <h2>Admin Panel Login</h2>
+            <form class="register-form" id="adminLoginForm">
+                <div class="form-group">
+                    <label for="email">Email</label>
+                    <input type="email" id="email" name="email" placeholder="masukkan email admin" required>
+                </div>
+                <div class="form-group">
+                    <label for="password">Password</label>
+                    <input type="password" id="password" name="password" placeholder="masukkan password" required>
+                </div>
+                <button type="submit" class="btn-register">Login</button>
+            </form>
+        </div>
+    </main>
+    <script type="module" src="../assets/js/main.js"></script>
+</body>
+</html>

--- a/admin/manage_competitions.php
+++ b/admin/manage_competitions.php
@@ -1,0 +1,84 @@
+<?php
+$pageTitle = 'Manajemen Lomba';
+$headerTitle = 'Manajemen Kompetisi & Lomba';
+include '_header.php'; // Memanggil header, yang sudah termasuk auth.php
+include '_sidebar.php'; // Memanggil sidebar dan header utama
+?>
+
+<div class="content-card">
+    <div class="toolbar">
+        <h4>Daftar Lomba</h4>
+        <button class="btn-primary">
+            <i class="fas fa-plus"></i> Tambah Lomba Baru
+        </button>
+    </div>
+
+    <table class="data-table" id="competitions-table">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Nama Lomba</th>
+                <th>Tanggal Pendaftaran</th>
+                <th>Biaya</th>
+                <th>Aksi</th>
+            </tr>
+        </thead>
+        <tbody>
+            </tbody>
+    </table>
+</div>
+
+<div id="competition-modal" class="modal-overlay" style="display: none;">
+    <div class="modal-content">
+        <div class="modal-header">
+            <h4 id="modal-title">Tambah Lomba Baru</h4>
+            <button id="close-modal-btn" class="close-button">&times;</button>
+        </div>
+        <div class="modal-body">
+            <form id="competition-form" enctype="multipart/form-data">
+                <input type="hidden" id="competition_id" name="competition_id">
+
+                <div class="form-group">
+                    <label for="nama_lomba">Nama Lomba</label>
+                    <input type="text" id="nama_lomba" name="nama_lomba" required>
+                </div>
+
+                <div class="form-group">
+                    <label for="deskripsi">Deskripsi</label>
+                    <textarea id="deskripsi" name="deskripsi" rows="4" required></textarea>
+                </div>
+
+                <div class="form-group-row">
+                    <div class="form-group">
+                        <label for="tanggal_mulai_daftar">Tanggal Mulai Pendaftaran</label>
+                        <input type="date" id="tanggal_mulai_daftar" name="tanggal_mulai_daftar" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="tanggal_akhir_daftar">Tanggal Akhir Pendaftaran</label>
+                        <input type="date" id="tanggal_akhir_daftar" name="tanggal_akhir_daftar" required>
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <label for="biaya">Biaya (Rp)</label>
+                    <input type="number" id="biaya" name="biaya" placeholder="Contoh: 50000" required>
+                </div>
+
+                <div class="form-group">
+                    <label for="banner_img">Banner/Poster Lomba</label>
+                    <input type="file" id="banner_img" name="banner_img" accept="image/png, image/jpeg, image/jpg">
+                </div>
+
+                <div class="modal-footer">
+                    <button type="button" id="cancel-btn" class="btn-secondary">Batal</button>
+                    <button type="submit" class="btn-primary">Simpan</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+
+<?php
+include '_footer.php'; // Memanggil footer
+?>

--- a/api/admin_add_competition.php
+++ b/api/admin_add_competition.php
@@ -1,0 +1,79 @@
+<?php
+// Mulai session dan panggil file auth.php untuk proteksi
+// Ini memastikan hanya admin yang bisa mengakses API ini
+require '../admin/auth.php';
+require '../config/database.php';
+
+header('Content-Type: application/json');
+
+// Pastikan metode request adalah POST
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405); // Method Not Allowed
+    echo json_encode(['status' => 'error', 'message' => 'Metode request tidak valid.']);
+    exit;
+}
+
+// --- Validasi dan Sanitasi Input ---
+$nama_lomba = trim($_POST['nama_lomba'] ?? '');
+$deskripsi = trim($_POST['deskripsi'] ?? '');
+$tanggal_mulai = $_POST['tanggal_mulai_daftar'] ?? '';
+$tanggal_akhir = $_POST['tanggal_akhir_daftar'] ?? '';
+$biaya = filter_var($_POST['biaya'] ?? 0, FILTER_VALIDATE_FLOAT);
+
+// Periksa apakah ada field yang kosong
+if (empty($nama_lomba) || empty($deskripsi) || empty($tanggal_mulai) || empty($tanggal_akhir) || $biaya === false) {
+    http_response_code(400); // Bad Request
+    echo json_encode(['status' => 'error', 'message' => 'Semua field wajib diisi dengan benar.']);
+    exit;
+}
+
+// --- Proses Upload Banner ---
+$banner_img_name = '';
+if (isset($_FILES['banner_img']) && $_FILES['banner_img']['error'] === UPLOAD_ERR_OK) {
+    $file = $_FILES['banner_img'];
+    $target_dir = "../assets/images/";
+    $allowed_extensions = ['jpg', 'jpeg', 'png'];
+    $file_extension = strtolower(pathinfo($file['name'], PATHINFO_EXTENSION));
+
+    if (!in_array($file_extension, $allowed_extensions)) {
+        http_response_code(400);
+        echo json_encode(['status' => 'error', 'message' => 'Format file banner tidak valid. Hanya JPG, JPEG, PNG.']);
+        exit;
+    }
+
+    // Buat nama file yang unik untuk menghindari tumpang tindih
+    $banner_img_name = 'banner_' . time() . '.' . $file_extension;
+    $target_file = $target_dir . $banner_img_name;
+
+    if (!move_uploaded_file($file['tmp_name'], $target_file)) {
+        http_response_code(500); // Internal Server Error
+        echo json_encode(['status' => 'error', 'message' => 'Gagal mengupload file banner.']);
+        exit;
+    }
+} else {
+    http_response_code(400);
+    echo json_encode(['status' => 'error', 'message' => 'Banner/Poster wajib diupload.']);
+    exit;
+}
+
+// --- Simpan ke Database ---
+$sql = "INSERT INTO competitions (nama_lomba, deskripsi, tanggal_mulai_daftar, tanggal_akhir_daftar, biaya, banner_img) VALUES (?, ?, ?, ?, ?, ?)";
+$stmt = $conn->prepare($sql);
+if ($stmt === false) {
+    http_response_code(500);
+    echo json_encode(['status' => 'error', 'message' => 'Gagal menyiapkan statement: ' . $conn->error]);
+    exit;
+}
+
+$stmt->bind_param("ssssds", $nama_lomba, $deskripsi, $tanggal_mulai, $tanggal_akhir, $biaya, $banner_img_name);
+
+if ($stmt->execute()) {
+    echo json_encode(['status' => 'success', 'message' => 'Lomba baru berhasil ditambahkan!']);
+} else {
+    http_response_code(500);
+    echo json_encode(['status' => 'error', 'message' => 'Gagal menyimpan data ke database: ' . $stmt->error]);
+}
+
+$stmt->close();
+$conn->close();
+?>

--- a/api/admin_delete_competition.php
+++ b/api/admin_delete_competition.php
@@ -1,0 +1,68 @@
+<?php
+// Panggil auth.php untuk memastikan hanya admin yang bisa mengakses
+require '../admin/auth.php';
+require '../config/database.php';
+
+header('Content-Type: application/json');
+
+// Pastikan metode request adalah POST untuk keamanan
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['status' => 'error', 'message' => 'Metode request tidak valid.']);
+    exit;
+}
+
+// Ambil ID dari body request
+$data = json_decode(file_get_contents('php://input'), true);
+$id = $data['id'] ?? null;
+
+if (empty($id)) {
+    http_response_code(400);
+    echo json_encode(['status' => 'error', 'message' => 'ID Lomba tidak disertakan.']);
+    exit;
+}
+
+$conn->begin_transaction();
+
+try {
+    // 1. Ambil nama file banner sebelum menghapus data
+    $stmt = $conn->prepare("SELECT banner_img FROM competitions WHERE id = ?");
+    $stmt->bind_param("i", $id);
+    $stmt->execute();
+    $result = $stmt->get_result();
+    $competition = $result->fetch_assoc();
+    $banner_img_name = $competition['banner_img'] ?? null;
+    $stmt->close();
+
+    // 2. Hapus data lomba dari database
+    $stmt = $conn->prepare("DELETE FROM competitions WHERE id = ?");
+    $stmt->bind_param("i", $id);
+    $stmt->execute();
+
+    // Periksa apakah ada baris yang terhapus
+    if ($stmt->affected_rows === 0) {
+        throw new Exception('Lomba dengan ID tersebut tidak ditemukan.');
+    }
+    $stmt->close();
+
+    // 3. Jika data berhasil dihapus dari DB, hapus file banner dari server
+    if ($banner_img_name) {
+        $file_path = '../assets/images/' . $banner_img_name;
+        if (file_exists($file_path)) {
+            unlink($file_path);
+        }
+    }
+
+    // Jika semua berhasil, commit transaksi
+    $conn->commit();
+    echo json_encode(['status' => 'success', 'message' => 'Lomba berhasil dihapus.']);
+
+} catch (Exception $e) {
+    // Jika ada kesalahan, rollback transaksi
+    $conn->rollback();
+    http_response_code(500);
+    echo json_encode(['status' => 'error', 'message' => 'Gagal menghapus lomba: ' . $e->getMessage()]);
+}
+
+$conn->close();
+?>

--- a/api/admin_get_competition_detail.php
+++ b/api/admin_get_competition_detail.php
@@ -1,0 +1,30 @@
+<?php
+// API ini tidak perlu proteksi admin karena hanya membaca data.
+require '../config/database.php';
+
+header('Content-Type: application/json');
+
+$id = $_GET['id'] ?? null;
+
+if (empty($id)) {
+    http_response_code(400);
+    echo json_encode(['status' => 'error', 'message' => 'ID Lomba tidak disertakan.']);
+    exit;
+}
+
+$stmt = $conn->prepare("SELECT id, nama_lomba, deskripsi, tanggal_mulai_daftar, tanggal_akhir_daftar, biaya, banner_img FROM competitions WHERE id = ?");
+$stmt->bind_param("i", $id);
+$stmt->execute();
+$result = $stmt->get_result();
+$competition = $result->fetch_assoc();
+
+if ($competition) {
+    echo json_encode(['status' => 'success', 'data' => $competition]);
+} else {
+    http_response_code(404); // Not Found
+    echo json_encode(['status' => 'error', 'message' => 'Lomba tidak ditemukan.']);
+}
+
+$stmt->close();
+$conn->close();
+?>

--- a/api/admin_get_competitions.php
+++ b/api/admin_get_competitions.php
@@ -1,0 +1,22 @@
+<?php
+require '../config/database.php';
+// Kita tidak memerlukan session check di sini karena ini adalah API read-only,
+// namun pada API CUD (Create, Update, Delete) nanti, session check akan sangat penting.
+
+header('Content-Type: application/json');
+
+$competitions = [];
+$sql = "SELECT id, nama_lomba, tanggal_mulai_daftar, tanggal_akhir_daftar, biaya FROM competitions ORDER BY id DESC";
+$result = $conn->query($sql);
+
+if ($result) {
+    while($row = $result->fetch_assoc()) {
+        $competitions[] = $row;
+    }
+    echo json_encode(['status' => 'success', 'data' => $competitions]);
+} else {
+    echo json_encode(['status' => 'error', 'message' => 'Gagal mengambil data kompetisi.']);
+}
+
+$conn->close();
+?>

--- a/api/admin_login.php
+++ b/api/admin_login.php
@@ -1,0 +1,53 @@
+<?php
+session_start();
+header('Content-Type: application/json');
+require '../config/database.php';
+
+if ($_SERVER['REQUEST_METHOD'] == 'POST') {
+    $email = $_POST['email'] ?? '';
+    $password = $_POST['password'] ?? '';
+
+    if (empty($email) || empty($password)) {
+        echo json_encode(['status' => 'error', 'message' => 'Email dan password harus diisi.']);
+        exit;
+    }
+
+    // Ambil data user, TERMASUK role
+    $stmt = $conn->prepare("SELECT id, nama, password, role FROM users WHERE email = ?");
+    $stmt->bind_param("s", $email);
+    $stmt->execute();
+    $result = $stmt->get_result();
+
+    if ($result->num_rows === 1) {
+        $user = $result->fetch_assoc();
+
+        // Verifikasi password DAN periksa role
+        if (password_verify($password, $user['password'])) {
+            if ($user['role'] === 'admin') {
+                // Jika berhasil, simpan semua data penting ke session
+                $_SESSION['user_id'] = $user['id'];
+                $_SESSION['user_nama'] = $user['nama'];
+                $_SESSION['user_role'] = $user['role'];
+
+                echo json_encode([
+                    'status' => 'success',
+                    'message' => 'Login berhasil!'
+                ]);
+            } else {
+                // Password benar, tapi bukan admin
+                echo json_encode(['status' => 'error', 'message' => 'Akses ditolak. Akun ini bukan admin.']);
+            }
+        } else {
+            // Password salah
+            echo json_encode(['status' => 'error', 'message' => 'Kombinasi email dan password salah.']);
+        }
+    } else {
+        // Email tidak ditemukan
+        echo json_encode(['status' => 'error', 'message' => 'Kombinasi email dan password salah.']);
+    }
+    $stmt->close();
+    $conn->close();
+} else {
+    echo json_encode(['status' => 'error', 'message' => 'Metode request tidak valid.']);
+}
+?>

--- a/api/admin_logout.php
+++ b/api/admin_logout.php
@@ -1,0 +1,8 @@
+<?php
+session_start();
+session_unset();
+session_destroy();
+
+header('Content-Type: application/json');
+echo json_encode(['status' => 'success', 'message' => 'Anda berhasil logout.']);
+?>

--- a/api/admin_update_competition.php
+++ b/api/admin_update_competition.php
@@ -1,0 +1,81 @@
+<?php
+require '../admin/auth.php'; // Proteksi Admin
+require '../config/database.php';
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['status' => 'error', 'message' => 'Metode request tidak valid.']);
+    exit;
+}
+
+// Ambil semua data dari form
+$id = $_POST['competition_id'] ?? null;
+$nama_lomba = trim($_POST['nama_lomba'] ?? '');
+$deskripsi = trim($_POST['deskripsi'] ?? '');
+$tanggal_mulai = $_POST['tanggal_mulai_daftar'] ?? '';
+$tanggal_akhir = $_POST['tanggal_akhir_daftar'] ?? '';
+$biaya = filter_var($_POST['biaya'] ?? 0, FILTER_VALIDATE_FLOAT);
+
+if (empty($id) || empty($nama_lomba) || empty($deskripsi) || empty($tanggal_mulai) || empty($tanggal_akhir) || $biaya === false) {
+    http_response_code(400);
+    echo json_encode(['status' => 'error', 'message' => 'Semua field wajib diisi dengan benar.']);
+    exit;
+}
+
+// Ambil nama banner lama dari DB
+$stmt = $conn->prepare("SELECT banner_img FROM competitions WHERE id = ?");
+$stmt->bind_param("i", $id);
+$stmt->execute();
+$result = $stmt->get_result();
+$existing_data = $result->fetch_assoc();
+$old_banner_name = $existing_data['banner_img'] ?? null;
+$stmt->close();
+
+$banner_img_name = $old_banner_name; // Default ke nama lama
+
+// Cek jika ada file banner baru yang diupload
+if (isset($_FILES['banner_img']) && $_FILES['banner_img']['error'] === UPLOAD_ERR_OK) {
+    // Logika upload file (sama seperti pada add_competition)
+    $file = $_FILES['banner_img'];
+    $target_dir = "../assets/images/";
+    $allowed_extensions = ['jpg', 'jpeg', 'png'];
+    $file_extension = strtolower(pathinfo($file['name'], PATHINFO_EXTENSION));
+
+    if (!in_array($file_extension, $allowed_extensions)) {
+        http_response_code(400);
+        echo json_encode(['status' => 'error', 'message' => 'Format file banner baru tidak valid.']);
+        exit;
+    }
+
+    $banner_img_name = 'banner_' . time() . '.' . $file_extension;
+    $target_file = $target_dir . $banner_img_name;
+
+    if (move_uploaded_file($file['tmp_name'], $target_file)) {
+        // Jika upload baru berhasil, hapus file banner lama
+        if ($old_banner_name && file_exists($target_dir . $old_banner_name)) {
+            unlink($target_dir . $old_banner_name);
+        }
+    } else {
+        http_response_code(500);
+        echo json_encode(['status' => 'error', 'message' => 'Gagal mengupload file banner baru.']);
+        exit;
+    }
+}
+
+// Update data di database
+$sql = "UPDATE competitions SET nama_lomba = ?, deskripsi = ?, tanggal_mulai_daftar = ?, tanggal_akhir_daftar = ?, biaya = ?, banner_img = ? WHERE id = ?";
+$stmt = $conn->prepare($sql);
+$stmt->bind_param("ssssdsi", $nama_lomba, $deskripsi, $tanggal_mulai, $tanggal_akhir, $biaya, $banner_img_name, $id);
+
+if ($stmt->execute()) {
+    echo json_encode(['status' => 'success', 'message' => 'Data lomba berhasil diperbarui!']);
+} else {
+    http_response_code(500);
+    echo json_encode(['status' => 'error', 'message' => 'Gagal memperbarui data di database: ' . $stmt->error]);
+}
+
+$stmt->close();
+$conn->close();
+?>

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,0 +1,344 @@
+/* assets/css/admin.css */
+
+:root {
+    --admin-bg: #f4f7fc;
+    --sidebar-bg: #1e293b;
+    --sidebar-text: #cbd5e1;
+    --sidebar-text-hover: #ffffff;
+    --sidebar-active-bg: #334155;
+    --card-bg: #ffffff;
+    --border-color: #e2e8f0;
+    --shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+}
+
+body {
+    background-color: var(--admin-bg);
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    margin: 0;
+}
+
+.admin-wrapper {
+    display: flex;
+}
+
+/* Sidebar Styles */
+.sidebar {
+    width: 260px;
+    background-color: var(--sidebar-bg);
+    color: var(--sidebar-text);
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+    position: fixed;
+}
+
+.sidebar-header {
+    padding: 1.5rem;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    border-bottom: 1px solid var(--sidebar-active-bg);
+}
+
+.sidebar-logo {
+    width: 40px;
+    height: 40px;
+}
+
+.sidebar-header h2 {
+    margin: 0;
+    font-size: 1.2rem;
+    color: var(--sidebar-text-hover);
+}
+
+.sidebar-nav {
+    flex-grow: 1;
+    padding: 1rem 0;
+}
+
+.sidebar-nav .nav-link {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.9rem 1.5rem;
+    color: var(--sidebar-text);
+    text-decoration: none;
+    transition: all 0.2s ease-in-out;
+}
+
+.sidebar-nav .nav-link:hover {
+    background-color: var(--sidebar-active-bg);
+    color: var(--sidebar-text-hover);
+}
+
+.sidebar-nav .nav-link.active {
+    background-color: var(--sidebar-active-bg);
+    color: var(--sidebar-text-hover);
+    border-left: 3px solid #3b82f6; /* Blue accent */
+}
+
+.sidebar-nav .nav-link i {
+    width: 20px;
+    text-align: center;
+}
+
+.sidebar-footer {
+    padding: 1.5rem;
+    border-top: 1px solid var(--sidebar-active-bg);
+}
+
+.sidebar-footer .logout {
+    text-decoration: none;
+    color: var(--sidebar-text);
+}
+
+/* Main Content Styles */
+.main-content {
+    margin-left: 260px;
+    width: calc(100% - 260px);
+    padding: 2rem;
+}
+
+.main-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 2rem;
+    background-color: var(--card-bg);
+    padding: 1rem 2rem;
+    border-radius: 8px;
+    box-shadow: var(--shadow);
+}
+
+.main-header h3 {
+    margin: 0;
+    font-size: 1.5rem;
+}
+
+.admin-profile {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.admin-profile i {
+    font-size: 1.8rem;
+    color: #64748b;
+}
+
+/* Dashboard Specific Styles */
+.dashboard-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1.5rem;
+    margin-bottom: 2rem;
+}
+
+.stat-card {
+    background-color: var(--card-bg);
+    padding: 1.5rem;
+    border-radius: 8px;
+    box-shadow: var(--shadow);
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+}
+
+.stat-icon {
+    width: 60px;
+    height: 60px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.5rem;
+    color: white;
+}
+.stat-icon.users { background-color: #3b82f6; }
+.stat-icon.competitions { background-color: #10b981; }
+.stat-icon.transactions { background-color: #f59e0b; }
+.stat-icon.revenue { background-color: #ef4444; }
+
+.stat-info p {
+    margin: 0;
+    color: #64748b;
+}
+
+.stat-info span {
+    font-size: 2rem;
+    font-weight: 700;
+}
+
+.content-card {
+    background-color: var(--card-bg);
+    padding: 2rem;
+    border-radius: 8px;
+    box-shadow: var(--shadow);
+}
+
+.toolbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1.5rem;
+}
+
+.toolbar h4 {
+    margin: 0;
+    font-size: 1.2rem;
+}
+
+.btn-primary {
+    background-color: #3b82f6;
+    color: white;
+    border: none;
+    padding: 0.7rem 1.2rem;
+    border-radius: 6px;
+    font-weight: 600;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    transition: background-color 0.2s;
+}
+.btn-primary:hover {
+    background-color: #2563eb;
+}
+
+/* Data Table Styles */
+.data-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.95rem;
+}
+
+.data-table thead {
+    background-color: #f1f5f9;
+}
+
+.data-table th, .data-table td {
+    padding: 1rem;
+    text-align: left;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.data-table tbody tr:hover {
+    background-color: #f8fafc;
+}
+
+.action-buttons {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.btn-icon {
+    border: none;
+    background: none;
+    cursor: pointer;
+    font-size: 1rem;
+    padding: 0.5rem;
+    border-radius: 4px;
+    transition: background-color 0.2s;
+}
+.btn-icon.btn-edit { color: #f59e0b; }
+.btn-icon.btn-delete { color: #ef4444; }
+
+.btn-icon:hover {
+    background-color: #e2e8f0;
+}
+
+/* Modal Styles */
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.6);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.modal-content {
+    background: white;
+    border-radius: 8px;
+    width: 90%;
+    max-width: 600px;
+    max-height: 90vh;
+    overflow-y: auto;
+}
+
+.modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem 1.5rem;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.modal-header h4 {
+    margin: 0;
+    font-size: 1.2rem;
+}
+
+.close-button {
+    background: none;
+    border: none;
+    font-size: 1.8rem;
+    cursor: pointer;
+    color: #64748b;
+}
+
+.modal-body {
+    padding: 1.5rem;
+}
+
+.form-group {
+    margin-bottom: 1rem;
+}
+
+.form-group label {
+    display: block;
+    margin-bottom: 0.5rem;
+    font-weight: 600;
+}
+
+.form-group input[type="text"],
+.form-group input[type="date"],
+.form-group input[type="number"],
+.form-group textarea {
+    width: 100%;
+    padding: 0.7rem;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    font-size: 1rem;
+}
+
+.form-group-row {
+    display: flex;
+    gap: 1rem;
+}
+
+.form-group-row .form-group {
+    flex: 1;
+}
+
+.modal-footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.75rem;
+    padding: 1rem 1.5rem;
+    border-top: 1px solid var(--border-color);
+}
+
+.btn-secondary {
+    background-color: #e2e8f0;
+    color: #1e293b;
+    border: none;
+    padding: 0.7rem 1.2rem;
+    border-radius: 6px;
+    font-weight: 600;
+    cursor: pointer;
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -11,24 +11,38 @@ import { initPayment } from './modules/payment.js';
 import { initTransactions } from './modules/transactions.js';
 import { initHistory } from './modules/history.js';
 import { initNews } from './modules/news.js';
-// Perbaiki baris import di bawah ini
+import { initAdmin } from './modules/admin.js'; // <-- BARU: Impor modul admin
 import { protectRoutes, handleLogout, loadUserData, setActiveNavLink, handleDynamicBackButton } from './modules/shared.js';
 
 // Jalankan semua skrip setelah DOM selesai dimuat
 document.addEventListener("DOMContentLoaded", function() {
-    
+
+    const currentPath = window.location.pathname;
+
+    // --- LOGIKA BARU UNTUK MEMISAHKAN ADMIN DAN USER ---
+    // Cek apakah kita berada di dalam folder admin
+    if (currentPath.includes('/admin/')) {
+        initAdmin(); // Jalankan hanya skrip untuk admin
+        return;      // Hentikan eksekusi agar skrip user tidak berjalan
+    }
+    // ----------------------------------------------------
+
+
+    // --- Skrip untuk halaman PENGGUNA (USER) ---
     if (!protectRoutes()) {
-        return;
+        return; // Hentikan jika pengguna belum login dan mencoba akses halaman terproteksi
     }
 
+    // Jalankan fungsi global untuk halaman pengguna
     handleDynamicBackButton();
-    // Jalankan fungsi global
-    setActiveNavLink(); // Ini akan mengaktifkan link navbar
+    setActiveNavLink();
     handleLogout();
-    loadUserData(); 
+    loadUserData();
 
-    const page = window.location.pathname.split("/").pop() || 'index.php';
+    // Dapatkan nama file halaman saat ini
+    const page = currentPath.split("/").pop() || 'index.php';
 
+    // Jalankan inisialisasi modul berdasarkan halaman yang aktif
     switch(page) {
         case 'login.php':
         case 'register.php':

--- a/assets/js/modules/admin.js
+++ b/assets/js/modules/admin.js
@@ -1,0 +1,287 @@
+/**
+ * assets/js/modules/admin.js
+ * Modul untuk menangani semua fungsi di panel admin.
+ */
+
+function handleAdminLoginForm() {
+    const adminLoginForm = document.getElementById('adminLoginForm');
+    if (adminLoginForm) {
+        adminLoginForm.addEventListener('submit', function(event) {
+            event.preventDefault();
+            const submitButton = this.querySelector('button[type="submit"]');
+            submitButton.disabled = true;
+            submitButton.textContent = 'Memproses...';
+
+            fetch('../api/admin_login.php', {
+                method: 'POST',
+                body: new FormData(this)
+            })
+            .then(response => response.json())
+            .then(data => {
+                if (data.status === 'success') {
+                    Swal.fire({
+                        icon: 'success',
+                        title: 'Berhasil!',
+                        text: data.message,
+                        timer: 1500,
+                        showConfirmButton: false
+                    }).then(() => {
+                        window.location.href = 'dashboard.php';
+                    });
+                } else {
+                    Swal.fire({
+                        icon: 'error',
+                        title: 'Oops...',
+                        text: data.message
+                    });
+                }
+            })
+            .catch(error => {
+                console.error('Kesalahan Login Admin:', error);
+                Swal.fire({
+                    icon: 'error',
+                    title: 'Kesalahan Jaringan',
+                    text: 'Tidak dapat terhubung ke server.'
+                });
+            })
+            .finally(() => {
+                submitButton.disabled = false;
+                submitButton.textContent = 'Login';
+            });
+        });
+    }
+}
+
+function handleAdminLogout() {
+    const logoutButton = document.getElementById('admin-logout-btn');
+    if (logoutButton) {
+        logoutButton.addEventListener('click', function(event) {
+            event.preventDefault();
+
+            Swal.fire({
+                title: 'Anda yakin ingin logout?',
+                icon: 'warning',
+                showCancelButton: true,
+                confirmButtonColor: '#3085d6',
+                cancelButtonColor: '#d33',
+                confirmButtonText: 'Ya, logout!',
+                cancelButtonText: 'Batal'
+            }).then((result) => {
+                if (result.isConfirmed) {
+                    fetch('../api/admin_logout.php', { method: 'POST' })
+                        .then(response => response.json())
+                        .then(data => {
+                            if (data.status === 'success') {
+                                window.location.href = 'index.php';
+                            }
+                        })
+                        .catch(error => console.error('Error logging out:', error));
+                }
+            });
+        });
+    }
+}
+
+function loadCompetitionsTable() {
+    const tableBody = document.querySelector('#competitions-table tbody');
+    if (!tableBody) return;
+
+    tableBody.innerHTML = '<tr><td colspan="5" style="text-align:center;">Memuat data...</td></tr>';
+
+    fetch('../api/admin_get_competitions.php')
+        .then(response => response.json())
+        .then(data => {
+            tableBody.innerHTML = '';
+            if (data.status === 'success' && data.data.length > 0) {
+                data.data.forEach(comp => {
+                    const row = `
+                        <tr>
+                            <td>${comp.id}</td>
+                            <td>${comp.nama_lomba}</td>
+                            <td>${new Date(comp.tanggal_mulai_daftar).toLocaleDateString('id-ID')} - ${new Date(comp.tanggal_akhir_daftar).toLocaleDateString('id-ID')}</td>
+                            <td>Rp ${Number(comp.biaya).toLocaleString('id-ID')}</td>
+                            <td class="action-buttons">
+                                <button class="btn-icon btn-edit" title="Edit"><i class="fas fa-pencil-alt"></i></button>
+                                <button class="btn-icon btn-delete" title="Hapus"><i class="fas fa-trash-alt"></i></button>
+                            </td>
+                        </tr>
+                    `;
+                    tableBody.innerHTML += row;
+                });
+            } else {
+                tableBody.innerHTML = '<tr><td colspan="5" style="text-align:center;">Tidak ada data untuk ditampilkan.</td></tr>';
+            }
+        })
+        .then(() => {
+            addTableEventListeners(); // Panggil fungsi ini setelah tabel dimuat
+        })
+        .catch(error => {
+            console.error('Error fetching competitions:', error);
+            tableBody.innerHTML = '<tr><td colspan="5" style="text-align:center;">Gagal memuat data. Periksa koneksi Anda.</td></tr>';
+        });
+}
+
+function setupCompetitionModal() {
+    const modal = document.getElementById('competition-modal');
+    const form = document.getElementById('competition-form');
+    const openModalBtn = document.querySelector('.toolbar .btn-primary');
+    const closeModalBtn = document.getElementById('close-modal-btn');
+    const cancelBtn = document.getElementById('cancel-btn');
+
+    if (!modal || !openModalBtn || !closeModalBtn || !form) return;
+
+    const openModal = () => {
+        form.reset();
+        document.getElementById('competition_id').value = ''; // Pastikan ID kosong untuk mode "Tambah"
+        document.getElementById('modal-title').textContent = 'Tambah Lomba Baru';
+        modal.style.display = 'flex';
+    };
+
+    const closeModal = () => {
+        modal.style.display = 'none';
+    };
+
+    openModalBtn.addEventListener('click', openModal);
+    closeModalBtn.addEventListener('click', closeModal);
+    cancelBtn.addEventListener('click', closeModal);
+    window.addEventListener('click', (event) => {
+        if (event.target === modal) {
+            closeModal();
+        }
+    });
+
+    form.addEventListener('submit', function(event) {
+        event.preventDefault();
+        const formData = new FormData(this);
+        const competitionId = formData.get('competition_id');
+        const apiUrl = competitionId ? '../api/admin_update_competition.php' : '../api/admin_add_competition.php';
+        
+        const submitButton = this.querySelector('button[type="submit"]');
+        submitButton.disabled = true;
+        submitButton.textContent = 'Menyimpan...';
+
+        fetch(apiUrl, {
+            method: 'POST',
+            body: formData
+        })
+        .then(response => response.json())
+        .then(data => {
+            if (data.status === 'success') {
+                Swal.fire('Berhasil!', data.message, 'success');
+                closeModal();
+                loadCompetitionsTable();
+            } else {
+                Swal.fire('Gagal!', data.message, 'error');
+            }
+        })
+        .catch(error => {
+            console.error('Error submitting form:', error);
+            Swal.fire('Error', 'Terjadi kesalahan pada jaringan.', 'error');
+        })
+        .finally(() => {
+            submitButton.disabled = false;
+            submitButton.textContent = 'Simpan';
+        });
+    });
+}
+
+function addTableEventListeners() {
+    const tableBody = document.querySelector('#competitions-table tbody');
+    if (!tableBody) return;
+
+    tableBody.addEventListener('click', function(event) {
+        const target = event.target.closest('button');
+        if (!target) return;
+
+        const row = target.closest('tr');
+        const competitionId = row.cells[0].textContent;
+
+        if (target.classList.contains('btn-delete')) {
+            handleDeleteCompetition(competitionId);
+        }
+
+        if (target.classList.contains('btn-edit')) {
+            const modal = document.getElementById('competition-modal');
+            const form = document.getElementById('competition-form');
+            form.reset();
+            openModalForEdit(competitionId);
+        }
+    });
+}
+
+function openModalForEdit(id) {
+    fetch(`../api/admin_get_competition_detail.php?id=${id}`)
+        .then(response => response.json())
+        .then(data => {
+            if (data.status === 'success') {
+                const comp = data.data;
+                const modal = document.getElementById('competition-modal');
+                
+                document.getElementById('competition_id').value = comp.id;
+                document.getElementById('nama_lomba').value = comp.nama_lomba;
+                document.getElementById('deskripsi').value = comp.deskripsi;
+                document.getElementById('tanggal_mulai_daftar').value = comp.tanggal_mulai_daftar;
+                document.getElementById('tanggal_akhir_daftar').value = comp.tanggal_akhir_daftar;
+                document.getElementById('biaya').value = parseFloat(comp.biaya);
+                
+                document.getElementById('modal-title').textContent = 'Edit Lomba';
+                modal.style.display = 'flex';
+            } else {
+                Swal.fire('Gagal!', 'Tidak dapat memuat data lomba.', 'error');
+            }
+        });
+}
+
+function handleDeleteCompetition(id) {
+    Swal.fire({
+        title: 'Anda Yakin?',
+        text: "Data lomba yang dihapus tidak dapat dikembalikan!",
+        icon: 'warning',
+        showCancelButton: true,
+        confirmButtonColor: '#d33',
+        cancelButtonColor: '#3085d6',
+        confirmButtonText: 'Ya, hapus!',
+        cancelButtonText: 'Batal'
+    }).then((result) => {
+        if (result.isConfirmed) {
+            fetch('../api/admin_delete_competition.php', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ id: id })
+            })
+            .then(response => response.json())
+            .then(data => {
+                if (data.status === 'success') {
+                    Swal.fire('Terhapus!', data.message, 'success');
+                    loadCompetitionsTable();
+                } else {
+                    Swal.fire('Gagal!', data.message, 'error');
+                }
+            })
+            .catch(error => {
+                console.error('Error deleting competition:', error);
+                Swal.fire('Error', 'Terjadi kesalahan pada jaringan.', 'error');
+            });
+        }
+    });
+}
+
+export function initAdmin() {
+    // Fungsi ini dipanggil dari main.js jika berada di folder /admin/
+    const page = window.location.pathname.split("/").pop();
+
+    handleAdminLogout();
+
+    switch(page) {
+        case 'index.php':
+            handleAdminLoginForm();
+            break;
+        case 'dashboard.php':
+            // Bisa tambahkan fungsi untuk memuat statistik dashboard di sini
+            break;
+        case 'manage_competitions.php':
+            loadCompetitionsTable();
+            setupCompetitionModal();
+            break;
+    }
+}


### PR DESCRIPTION
Adds a complete CRUD (Create, Read, Update, Delete) functionality for competitions within the admin panel.

- Creates a new page at /admin/manage_competitions.php to display and manage all competitions.
- Implements a reusable modal form for both adding new and editing existing competitions.
- Introduces secure, admin-protected API endpoints for create, read, update, and delete operations.
- Integrates dynamic client-side handling for a seamless UX without page reloads."